### PR TITLE
Bug fixing

### DIFF
--- a/CheatConfig.cs
+++ b/CheatConfig.cs
@@ -51,7 +51,7 @@ namespace Josiwe.ATS.Cheats
         // Higher Traders Prices - Traders gossip about you doing pretty well lately. All your goods are worth 50% less to traders.
         public float Prestige_10_Amount { get; set; } = -0.5f;
         // Fewer Blueprints Options - The greedy Royal Archivist sold most of the blueprints to traders and fled the Citadel. You have 2 fewer blueprint choices.
-        public int Prestige_12_Amount { get; set; } = 1;
+        public int Prestige_12_Amount { get; set; } = -2;
         // Fewer Cornerstones Options - The Royal Envoy comes to you with bad news. The Queen has restricted your cornerstone choices by 2.
         public int Prestige_13_Amount { get; set; } = 2;
         // Lower Impatience Reduction - The Queen expects a lot from a viceroy of your rank. Impatience falls by 0.5 points less for every Reputation point you gain.

--- a/Explorer.Config.json
+++ b/Explorer.Config.json
@@ -49,7 +49,7 @@
     "Prestige_10_Description": "Higher Traders Prices - Traders gossip about you doing pretty well lately. All your goods are worth 50% less to traders.",
     "Prestige_10_Amount": -0.5,
     "Prestige_12_Description": "Fewer Blueprints Options - The greedy Royal Archivist sold most of the blueprints to traders and fled the Citadel. You have 2 fewer blueprint choices.",
-    "Prestige_12_Amount": 1,
+    "Prestige_12_Amount": -2,
     "Prestige_13_Description": "Fewer Cornerstones Options - The Royal Envoy comes to you with bad news. The Queen has restricted your cornerstone choices by 2.",
     "Prestige_13_Amount": 1,
     "Prestige_14_Description": "Lower Impatience Reduction - The Queen expects a lot from a viceroy of your rank. Impatience falls by 0.5 points less for every Reputation Point you gain.",

--- a/GluttonForPunishment.Config.json
+++ b/GluttonForPunishment.Config.json
@@ -49,7 +49,7 @@
     "Prestige_10_Description": "Higher Traders Prices - Traders gossip about you doing pretty well lately. All your goods are worth 50% less to traders.",
     "Prestige_10_Amount": -0.75,
     "Prestige_12_Description": "Fewer Blueprints Options - The greedy Royal Archivist sold most of the blueprints to traders and fled the Citadel. You have 2 fewer blueprint choices.",
-    "Prestige_12_Amount": 1,
+    "Prestige_12_Amount": -2,
     "Prestige_13_Description": "Fewer Cornerstones Options - The Royal Envoy comes to you with bad news. The Queen has restricted your cornerstone choices by 2.",
     "Prestige_13_Amount": 1,
     "Prestige_14_Description": "Lower Impatience Reduction - The Queen expects a lot from a viceroy of your rank. Impatience falls by 0.5 points less for every Reputation Point you gain.",

--- a/Josiwe.ATS.Cheats.Config.json
+++ b/Josiwe.ATS.Cheats.Config.json
@@ -49,7 +49,7 @@
     "Prestige_10_Description": "Higher Traders Prices - Traders gossip about you doing pretty well lately. All your goods are worth 50% less to traders.",
     "Prestige_10_Amount": -0.5,
     "Prestige_12_Description": "Fewer Blueprints Options - The greedy Royal Archivist sold most of the blueprints to traders and fled the Citadel. You have 2 fewer blueprint choices.",
-    "Prestige_12_Amount": 1,
+    "Prestige_12_Amount": -2,
     "Prestige_13_Description": "Fewer Cornerstones Options - The Royal Envoy comes to you with bad news. The Queen has restricted your cornerstone choices by 2.",
     "Prestige_13_Amount": 1,
     "Prestige_14_Description": "Lower Impatience Reduction - The Queen expects a lot from a viceroy of your rank. Impatience falls by 0.5 points less for every Reputation Point you gain.",

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -122,7 +122,11 @@ namespace Josiwe.ATS.Cheats
                     switch (modifier.effect.DisplayNameKey)
                     {
                         case "Effect_FewerBlueprintsOptions_Name":
-                            if (_configuration.Prestige_12_Amount < 0.0f) break;
+                            if (_configuration.Prestige_12_Amount > 0.0f)
+                            {
+                                modifier.effect.ConsumeAsNonPerk();
+                                break;
+                            }
                             var p12Model = (ReputationRewardsBonusOptionsEffectModel)modifier.effect;
                             p12Model.amount = _configuration.Prestige_12_Amount; // change the amount
                             p12Model.ConsumeAsNonPerk();
@@ -177,79 +181,131 @@ namespace Josiwe.ATS.Cheats
                         switch (modifier.effect.DisplayNameKey)
                         {
                             case "Effect_CrumblingSeal_Name":
-                                if (_configuration.Prestige_2_Amount < 0.0f) break;
+                                if (_configuration.Prestige_2_Amount < 0.0f)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p2Model = (SeasonLengthEffectModel)modifier.effect;
                                 p2Model.amount = _configuration.Prestige_2_Amount;
                                 p2Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_HigherBlueprintsRerollCost_Name":
-                                if (_configuration.Prestige_4_Amount < 0) break;
+                                if (_configuration.Prestige_4_Amount < 0)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p4Model = (ReputationRewardsRerollCostEffectModel)modifier.effect;
                                 p4Model.amount = _configuration.Prestige_4_Amount;
                                 p4Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_FasterLeaving_Name":
-                                if (_configuration.Prestige_5_Amount < 0.0f) break;
+                                if (_configuration.Prestige_5_Amount < 0.0f)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p5Model = (LeavingRateEffectModel)modifier.effect;
                                 p5Model.amount = _configuration.Prestige_5_Amount;
                                 p5Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_WetSoil_Name":
-                                if (_configuration.Prestige_6_Amount < 0.0f) break;
+                                if (_configuration.Prestige_6_Amount < 0.0f)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p6Model = (ConstructionCostEffectModel)modifier.effect;
                                 p6Model.amount = _configuration.Prestige_6_Amount;
                                 p6Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_Parasites_Name":
-                                if (_configuration.Prestige_7_Amount < 0.0f) break;
+                                if (_configuration.Prestige_7_Amount < 0.0f)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p7Model = (ChanceForExtraConsumptionEffectModel)modifier.effect;
                                 p7Model.amount = _configuration.Prestige_7_Amount;
                                 p7Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_HigherNeedsConsumptionRate_Name":
-                                if (_configuration.Prestige_8_Amount < 0.0f) break;
+                                if (_configuration.Prestige_8_Amount < 0.0f)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p8Model = (ChanceForExtraConsumptionEffectModel)modifier.effect;
                                 p8Model.amount = _configuration.Prestige_8_Amount;
                                 p8Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_LongerRelicsWorkingTime_Name":
-                                if (_configuration.Prestige_9_Amount > 0.0f) break;
+                                if (_configuration.Prestige_9_Amount > 0.0f)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p9Model = (RelicsWorkingTimeRateEffectModel)modifier.effect;
                                 p9Model.amount = _configuration.Prestige_9_Amount;
                                 p9Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_HigherTradersPrices_Name":
-                                if (_configuration.Prestige_10_Amount > 0.0f) break;
+                                if (_configuration.Prestige_10_Amount > 0.0f)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p10Model = (TraderGlobalSellPriceEffectModel)modifier.effect;
                                 p10Model.amount = _configuration.Prestige_10_Amount;
                                 p10Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_FewerCornerstonesOptions_Name":
-                                if (_configuration.Prestige_13_Amount < 0) break;
+                                if (_configuration.Prestige_13_Amount < 0)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p13Model = (SeasonalRewardsBonusOptionsEffectModel)modifier.effect;
                                 p13Model.amount = _configuration.Prestige_13_Amount;
                                 p13Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_LowerImpatienceReduction_Name":
-                                if (_configuration.Prestige_14_Amount < 0.0f) break;
+                                if (_configuration.Prestige_14_Amount < 0.0f)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p14Model = (BonusReputationPenaltyPerReputationEffectModel)modifier.effect;
                                 p14Model.amount = _configuration.Prestige_14_Amount;
                                 p14Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_GlobalReputationTresholdIncrease_Name":
-                                if (_configuration.Prestige_15_Amount < 0) break;
+                                if (_configuration.Prestige_15_Amount < 0)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p15Model = (BonusGlobalReputationTresholdIncreaseEffectModel)modifier.effect;
                                 p15Model.amount = _configuration.Prestige_15_Amount;
                                 p15Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_AscensionHungerMultiplier_Name":
-                                if (_configuration.Prestige_17_Amount < 0) break;
+                                if (_configuration.Prestige_17_Amount < 0)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p17Model = (HungerMultiplierEffectModel)modifier.effect;
                                 p17Model.amount = _configuration.Prestige_17_Amount;
                                 p17Model.ConsumeAsNonPerk();
                                 break;
                             case "Effect_FasterFuelSacrifice_Name":
-                                if (_configuration.Prestige_18_Amount > 0.0f) break;
+                                if (_configuration.Prestige_18_Amount > 0.0f)
+                                {
+                                    modifier.effect.ConsumeAsNonPerk();
+                                    break;
+                                }
                                 var p18Model = (HearthSacraficeTimeEffectModel)modifier.effect;
                                 p18Model.amount = _configuration.Prestige_18_Amount;
                                 p18Model.ConsumeAsNonPerk();
@@ -378,8 +434,7 @@ namespace Josiwe.ATS.Cheats
         public static bool AddReputationPenalty_PrePatch(ReputationService __instance, float amount, ReputationChangeSource type, bool force, string reason = null)
         {
             if (Mathf.Approximately(amount, 0.0f)
-                || !force
-                && __instance.IsGameFinished()
+                || (!force && __instance.IsGameFinished())
                 || _configuration == null
                 || _configuration.ImpatienceMultiplier < 0.0f
                 || _configuration.ImpatienceStopgap < 0)
@@ -497,21 +552,20 @@ namespace Josiwe.ATS.Cheats
         [HarmonyPrefix]
         private static bool PrepareInitialPoints_PrePatch(ReputationRewardsService __instance)
         {
-            if (_configuration == null
+            if (__instance.State.initialReputationPicksGranted
+                || _configuration == null
                 || !_configuration.WildcardBlueprints
                 || _configuration.BlueprintsMultiplier < 0
                 || MB.TutorialService.IsAnyTutorial(GameMB.Biome))
                 return true; // run the original game method
 
             WriteLog("WildcardBlueprints: " + _configuration.WildcardBlueprints.ToString());
-            //WriteLog("Initial Reputation Picks Granted: " + __instance.State.initialReputationPicksGranted.ToString());
+            WriteLog("Initial Reputation Picks Granted: " + __instance.State.initialReputationPicksGranted.ToString());
 
-            if (__instance.State.initialReputationPicksGranted == false)
-            {
-                __instance.State.initialReputationPicksGranted = true;
-                WriteLog($"Generating {_configuration.BlueprintsMultiplier} wildcard blueprint picks");
-                Serviceable.EffectsService.GrantWildcardPick(_configuration.BlueprintsMultiplier);
-            }
+            __instance.State.initialReputationPicksGranted = true;
+            WriteLog($"Generating {_configuration.BlueprintsMultiplier} wildcard blueprint picks");
+            Serviceable.EffectsService.GrantWildcardPick(_configuration.BlueprintsMultiplier);
+            __instance.State.lastGrantedReputationReward -= __instance.ReputationConfig.initialReputationRewards;
 
             return false; // do not run the original game method
         }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -476,7 +476,11 @@ namespace Josiwe.ATS.Cheats
         {
             if (_configuration == null
                 || !_configuration.MoarSeasonRewards)
+            {
+                // reset the bonus season rewards back to default
+                Serviceable.MetaStateService.Perks.bonusSeasonRewardsAmount = 0;
                 return true; // run the original method
+            }
 
             // when the model is null it's replaced with random model in the cornerstone service, this is my hacky patch
             if (model == null)

--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ Here you'll find a detailed description of the type and effect of each setting i
 
 **Prestige_12_Amount**
 <br>`Fewer Blueprints Options - The greedy Royal Archivist sold most of the blueprints to traders and fled the Citadel. You have 2 fewer blueprint choices`
-- Integer: _accepts any positive whole number greater than zero (i.e. 1, 3, 5)_
-- when set to any number greater than one, will make the penalty larger
-- setting this to 1 uses the game's default logic
+- Integer: _accepts any **negative** whole number (i.e. -1, -3, -5)_
+- when set to any negative number, will make the penalty larger
+- setting this to -2 uses the game's default logic
 
 **Prestige_13_Amount**
 <br>`Fewer Cornerstones Options - The Royal Envoy comes to you with bad news. The Queen has restricted your cornerstone choices by 2`

--- a/Vanilla.Config.json
+++ b/Vanilla.Config.json
@@ -1,7 +1,7 @@
 {
     "WorldMap": "Where you pick a tile to start a settlement in",
 
-    "ZoomMultiplier": 7.0,
+    "ZoomMultiplier": 1.0,
     "AllRacesInWorldMap": false,
     "BonusPreparationPoints": 0,
 
@@ -49,7 +49,7 @@
     "Prestige_10_Description": "Higher Traders Prices - Traders gossip about you doing pretty well lately. All your goods are worth 50% less to traders.",
     "Prestige_10_Amount": -0.5,
     "Prestige_12_Description": "Fewer Blueprints Options - The greedy Royal Archivist sold most of the blueprints to traders and fled the Citadel. You have 2 fewer blueprint choices.",
-    "Prestige_12_Amount": 1,
+    "Prestige_12_Amount": -2,
     "Prestige_13_Description": "Fewer Cornerstones Options - The Royal Envoy comes to you with bad news. The Queen has restricted your cornerstone choices by 2.",
     "Prestige_13_Amount": 1,
     "Prestige_14_Description": "Lower Impatience Reduction - The Queen expects a lot from a viceroy of your rank. Impatience falls by 0.5 points less for every Reputation Point you gain.",


### PR DESCRIPTION
 Fixed an issue with cornerstone picks in which the code wasn't resetting to default values on vanilla settings.

 Fixed an issue with the prestige_12 cheat in which the default amount was incorrectly set to 1 instead of -2

Added more defensive code in each prestige case